### PR TITLE
 ci: move to matrix strategy and build for Debian 13 / Trixie

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -5,22 +5,42 @@ on:
     branches:
       - master
       - github-ci
+    tags:
+      - 'upstream/*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  build-amd64:
-    runs-on: ubuntu-latest
-    container: debian:12
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            container: debian:12
+            distro: bookworm
+          - runner: ubuntu-24.04-arm
+            container: debian:12
+            distro: bookworm
+          - runner: ubuntu-latest
+            container: debian:13
+            distro: trixie
+          - runner: ubuntu-24.04-arm
+            container: debian:13
+            distro: trixie
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     steps:
       - name: install dependencies
         run: |
           echo "MIRRORSITE=http://deb.debian.org/debian" > /etc/pbuilderrc
-          apt update
-          apt install -y git-buildpackage build-essential debhelper-compat default-libmysqlclient-dev krb5-multidev libapparmor-dev libbz2-dev libcap-dev libdb-dev libexpat-dev libexttextcat-dev libicu-dev libldap2-dev liblua5.4-dev liblz4-dev liblzma-dev libpam0g-dev libpq-dev libsasl2-dev libsodium-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libwrap0-dev libzstd-dev pkg-config zlib1g-dev git libunwind-dev rsync
+          mkdir -p -m 755 /etc/apt/keyrings
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          apt-get update -q
+          apt-get install -y gh git-buildpackage build-essential debhelper-compat default-libmysqlclient-dev krb5-multidev libapparmor-dev libbz2-dev libcap-dev libdb-dev libexpat-dev libexttextcat-dev libicu-dev libldap2-dev liblua5.4-dev liblz4-dev liblzma-dev libpam0g-dev libpq-dev libsasl2-dev libsodium-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libtirpc-dev libwrap0-dev libzstd-dev pkg-config zlib1g-dev git libunwind-dev rsync
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: dovecot
           show-progress: false
@@ -36,41 +56,31 @@ jobs:
           DEB_BUILD_OPTIONS=nocheck gbp buildpackage --git-ignore-branch --git-no-pristine-tar -us -uc
 
       - name: upload .deb files
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           mkdir -p "$HOME/.ssh"
           echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
           chmod 600 "$HOME/.ssh/key"
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/build-area/ "${{ secrets.USERNAME }}@download.delta.chat:/var/www/html/download/dovecot/"
+          version=$(cd dovecot && dpkg-parsechangelog -Sversion | sed 's/^1://')
+          rsync -rLvh --ignore-existing --mkpath \
+            -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" \
+            $GITHUB_WORKSPACE/build-area/ \
+            "${{ secrets.USERNAME }}@download.delta.chat:/var/www/html/download/dovecot/${{ matrix.distro }}/${version}/"
 
-  build-arm:
-    runs-on: ubuntu-24.04-arm
-    container: debian:12
-    steps:
-      - name: install dependencies
+      - name: upload to github release
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          echo "MIRRORSITE=http://deb.debian.org/debian" > /etc/pbuilderrc
-          apt update
-          apt install -y git-buildpackage build-essential debhelper-compat default-libmysqlclient-dev krb5-multidev libapparmor-dev libbz2-dev libcap-dev libdb-dev libexpat-dev libexttextcat-dev libicu-dev libldap2-dev liblua5.4-dev liblz4-dev liblzma-dev libpam0g-dev libpq-dev libsasl2-dev libsodium-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libwrap0-dev libzstd-dev pkg-config zlib1g-dev git libunwind-dev rsync
-
-      - uses: actions/checkout@v4
-        with:
-          path: dovecot
-          show-progress: false
-          fetch-depth: 0
-
-      - name: build
-        run: |
-          cd dovecot
-          git rm -r .github
-          git config --local user.name "test"
-          git config --local user.email "test@example.org"
-          git commit -am "CI: remove .github directory before building"
-          DEB_BUILD_OPTIONS=nocheck gbp buildpackage --git-ignore-branch --git-no-pristine-tar -us -uc
-
-      - name: upload .deb files
-        run: |
-          mkdir -p "$HOME/.ssh"
-          echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
-          chmod 600 "$HOME/.ssh/key"
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/build-area/ "${{ secrets.USERNAME }}@download.delta.chat:/var/www/html/download/dovecot/"
-
+          version=$(cd dovecot && dpkg-parsechangelog -Sversion | sed 's/^1://')
+          tag="upstream/${version}"
+          for f in $GITHUB_WORKSPACE/build-area/dovecot-core_*.deb \
+                   $GITHUB_WORKSPACE/build-area/dovecot-imapd_*.deb \
+                   $GITHUB_WORKSPACE/build-area/dovecot-lmtpd_*.deb; do
+            mv "$f" "${f%.deb}_${{ matrix.distro }}.deb"
+          done
+          gh release create "$tag" --title "$tag" || true
+          gh release upload "$tag" --clobber \
+            $GITHUB_WORKSPACE/build-area/dovecot-core_*_${{ matrix.distro }}.deb \
+            $GITHUB_WORKSPACE/build-area/dovecot-imapd_*_${{ matrix.distro }}.deb \
+            $GITHUB_WORKSPACE/build-area/dovecot-lmtpd_*_${{ matrix.distro }}.deb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-staging-deb.yml
+++ b/.github/workflows/build-staging-deb.yml
@@ -7,15 +7,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  staging-amd64:
-    runs-on: ubuntu-latest
-    container: debian:12
+  staging:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            container: debian:12
+            distro: bookworm
+          - runner: ubuntu-24.04-arm
+            container: debian:12
+            distro: bookworm
+          - runner: ubuntu-latest
+            container: debian:13
+            distro: trixie
+          - runner: ubuntu-24.04-arm
+            container: debian:13
+            distro: trixie
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     steps:
       - name: install dependencies
         run: |
           echo "MIRRORSITE=http://deb.debian.org/debian" > /etc/pbuilderrc
           apt update
-          apt install -y git-buildpackage build-essential debhelper-compat default-libmysqlclient-dev krb5-multidev libapparmor-dev libbz2-dev libcap-dev libdb-dev libexpat-dev libexttextcat-dev libicu-dev libldap2-dev liblua5.4-dev liblz4-dev liblzma-dev libpam0g-dev libpq-dev libsasl2-dev libsodium-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libwrap0-dev libzstd-dev pkg-config zlib1g-dev git libunwind-dev rsync
+          apt install -y git-buildpackage build-essential debhelper-compat default-libmysqlclient-dev krb5-multidev libapparmor-dev libbz2-dev libcap-dev libdb-dev libexpat-dev libexttextcat-dev libicu-dev libldap2-dev liblua5.4-dev liblz4-dev liblzma-dev libpam0g-dev libpq-dev libsasl2-dev libsodium-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libtirpc-dev libwrap0-dev libzstd-dev pkg-config zlib1g-dev git libunwind-dev rsync
 
       - uses: actions/checkout@v4
         with:
@@ -37,41 +52,9 @@ jobs:
           mkdir -p "$HOME/.ssh"
           echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
           chmod 600 "$HOME/.ssh/key"
-          export branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          mv $GITHUB_WORKSPACE/build-area staging-$branch
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" staging-$branch "${{ secrets.USERNAME }}@download.delta.chat:/var/www/html/download/dovecot/"
-
-  staging-arm:
-    runs-on: ubuntu-24.04-arm
-    container: debian:12
-    steps:
-      - name: install dependencies
-        run: |
-          echo "MIRRORSITE=http://deb.debian.org/debian" > /etc/pbuilderrc
-          apt update
-          apt install -y git-buildpackage build-essential debhelper-compat default-libmysqlclient-dev krb5-multidev libapparmor-dev libbz2-dev libcap-dev libdb-dev libexpat-dev libexttextcat-dev libicu-dev libldap2-dev liblua5.4-dev liblz4-dev liblzma-dev libpam0g-dev libpq-dev libsasl2-dev libsodium-dev libsqlite3-dev libssl-dev libstemmer-dev libsystemd-dev libwrap0-dev libzstd-dev pkg-config zlib1g-dev git libunwind-dev rsync
-
-      - uses: actions/checkout@v4
-        with:
-          path: dovecot
-          show-progress: false
-          fetch-depth: 0
-
-      - name: build
-        run: |
-          cd dovecot
-          git rm -r .github
-          git config --local user.name "test"
-          git config --local user.email "test@example.org"
-          git commit -am "CI: remove .github directory before building"
-          DEB_BUILD_OPTIONS=nocheck gbp buildpackage --git-no-pristine-tar --git-ignore-branch -us -uc
-
-      - name: upload .deb files
-        run: |
-          mkdir -p "$HOME/.ssh"
-          echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
-          chmod 600 "$HOME/.ssh/key"
-          export branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          mv $GITHUB_WORKSPACE/build-area staging-$branch
-          rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" staging-$branch "${{ secrets.USERNAME }}@download.delta.chat:/var/www/html/download/dovecot/"
-
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          safe_branch=$(echo "$branch" | tr '/' '-')
+          rsync -rILvh --mkpath \
+            -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" \
+            $GITHUB_WORKSPACE/build-area/ \
+            "${{ secrets.USERNAME }}@download.delta.chat:/var/www/html/download/dovecot/staging/${safe_branch}/${{ matrix.distro }}/"


### PR DESCRIPTION
Replace the copied workflows with a matrix workflow for Debian 12/13 and
Arm/AMD64.

replaces #7 (slash in branch name breaks upload)