### PR TITLE
ci: cache ccache across build and reprotest runs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,13 +39,22 @@ jobs:
       - name: install packaging tools
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends ca-certificates git git-buildpackage devscripts build-essential fakeroot rsync openssh-client
+          apt-get install -y --no-install-recommends ca-certificates git git-buildpackage devscripts build-essential fakeroot rsync openssh-client ccache
 
       - uses: actions/checkout@v7
         with:
           path: dovecot
           show-progress: false
           fetch-depth: 0
+
+      # Persist ccache across runs, keyed per distro/arch 
+      - name: cache ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-${{ inputs.distro }}-${{ inputs.arch }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ inputs.distro }}-${{ inputs.arch }}-
 
       # Add a distro-distinct version onto the changelog. The committed top
       # entry is UNRELEASED with a distro-neutral base version (1:...+chatmail2);
@@ -74,6 +83,18 @@ jobs:
 
       - name: install build dependencies
         run: apt-get build-dep -y --no-install-recommends ./dovecot
+
+      # Recreate symlinks explicitly after install
+      - name: fix ccache compiler symlinks
+        run: |
+          mkdir -p /usr/lib/ccache/bin
+          for c in gcc cc g++ c++; do
+            command -v "$c" >/dev/null 2>&1 && ln -sf /usr/bin/ccache "/usr/lib/ccache/bin/$c"
+          done
+          for c in /usr/bin/gcc-* /usr/bin/g++-*; do
+            [ -e "$c" ] && ln -sf /usr/bin/ccache "/usr/lib/ccache/bin/$(basename "$c")"
+          done
+          ls -la /usr/lib/ccache/bin
 
       # Build as an unprivileged user, defer tests to separate
       # step below. This avoids failing the build step on timing-flaky tests such
@@ -112,9 +133,22 @@ jobs:
           # `git ls-tree master^{tree}`, point it at the checked-out commit.
           branch="--git-ignore-branch --git-debian-branch=HEAD $tree_opt"
 
+          # /usr/lib/ccache/bin holds gcc/cc/g++/c++ symlinks, but gbp's
+          # default builder (debuild) resets PATH to a fixed safe list before
+          # running dpkg-buildpackage, and we have to use debuild's
+          # --prepend-path/--set-envvar that must come before -i/-I.
+          export CCACHE_DIR="$GITHUB_WORKSPACE/.ccache"
+          ccache --max-size=500M >/dev/null
+
           # --git-no-purge: keep export tree (build-area/dovecot-*)
           # after a successful build for test step further on
-          DEB_BUILD_OPTIONS="parallel=$par nocheck" timeout -k 60 75m gbp buildpackage --git-no-pristine-tar --git-no-purge $branch -us -uc
+          DEB_BUILD_OPTIONS="parallel=$par nocheck" timeout -k 60 75m gbp buildpackage \
+            --git-builder="debuild --prepend-path=/usr/lib/ccache/bin --set-envvar=CCACHE_DIR=$CCACHE_DIR -i -I" \
+            --git-no-pristine-tar --git-no-purge $branch -us -uc
+          echo "=== ccache stats ==="
+          ccache -s
+          du -sh "$CCACHE_DIR"
+          echo "===================="
           EOF
           runuser -u builder -- bash /tmp/ci-build.sh
 
@@ -345,12 +379,33 @@ jobs:
           name: build-area-${{ inputs.distro }}-${{ inputs.arch }}
           path: build-area
 
+      # Reuse build artifacts from amd64 leg
+      - name: cache ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-${{ inputs.distro }}-amd64-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ inputs.distro }}-amd64-
+
       - name: install reprotest and build dependencies
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends reprotest locales-all dpkg-dev fakeroot
+          apt-get install -y --no-install-recommends reprotest locales-all dpkg-dev fakeroot ccache
           dpkg-source -x build-area/dovecot_*.dsc /tmp/dovecot-src
           apt-get build-dep -y --no-install-recommends /tmp/dovecot-src
+
+      # Recreate symlinks explicitly  after install
+      - name: fix ccache compiler symlinks
+        run: |
+          mkdir -p /usr/lib/ccache/bin
+          for c in gcc cc g++ c++; do
+            command -v "$c" >/dev/null 2>&1 && ln -sf /usr/bin/ccache "/usr/lib/ccache/bin/$c"
+          done
+          for c in /usr/bin/gcc-* /usr/bin/g++-*; do
+            [ -e "$c" ] && ln -sf /usr/bin/ccache "/usr/lib/ccache/bin/$(basename "$c")"
+          done
+          ls -la /usr/lib/ccache/bin
 
       - name: run reprotest
         run: |
@@ -358,11 +413,21 @@ jobs:
           install -d -o builder -g builder /build/reproducible-path
           cp build-area/dovecot_*.dsc build-area/dovecot_*.tar.* /build/reproducible-path/
           chown builder:builder /build/reproducible-path/*
+          # Create/own cache dir explicitly
+          install -d -o builder -g builder "$GITHUB_WORKSPACE/.ccache"
           cd /build/reproducible-path
+          # Setting PATH/CCACHE_DIR on reprotest process is overridden by its
+          # "environment" variation dimension; insert ccache directly into
+          # build_command via --auto-preset-expr: prepend() does string
+          # concatenation with no separator; as the build_command is &&
+          # chained, we need to export so env vars reach all commands.
+          ccache_dir="$GITHUB_WORKSPACE/.ccache"
+          preset_expr="_.prepend.build_command('export CCACHE_DIR=${ccache_dir}; export PATH=/usr/lib/ccache/bin:\$PATH; ')"
           runuser -u builder -- env HOME=/home/builder \
             DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
             reprotest --verbosity=1 --no-diffoscope \
               --store-dir=/home/builder/reprotest-out \
+              --auto-preset-expr "$preset_expr" \
               --vary=-time \
               --vary=-build_path \
               --vary=-user_group \
@@ -370,6 +435,11 @@ jobs:
               --vary=-fileordering \
               --vary=-aslr \
               dovecot_*.dsc -- null
+          echo "=== ccache stats  ==="
+          runuser -u builder -- env CCACHE_DIR="$GITHUB_WORKSPACE/.ccache" \
+            PATH="/usr/lib/ccache/bin:$PATH" ccache -s
+          du -sh "$GITHUB_WORKSPACE/.ccache"
+          echo "====================="
 
       - name: diffoscope on failure
         if: failure()


### PR DESCRIPTION
Every leg recompiles from scratch each run, and reprotest recompiles twice more on top of that. This commit introduces ccache  for both jobs, keyed per distro/arch; reprotest reuses the build job's artifacts. Cache size capped at --max-size=500M for now, stats logged;  with these on the first (cold) run:
```
Cacheable calls:   1800 / 2374 (75.82%)
  Hits:              13 / 1800 ( 0.72%)
  Misses:          1787 / 1800 (99.28%)
  Cache size (GB): 0.13 / 2.00 ( 6.47%)
  ```